### PR TITLE
views.py add_header needed return value

### DIFF
--- a/rfpy/views.py
+++ b/rfpy/views.py
@@ -299,3 +299,4 @@ def add_header(r):
     r.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
     r.headers['Pragma'] = 'no-cache'
     r.headers['Expires'] = '0'
+    return r


### PR DESCRIPTION
add_header didn't have return value.

This caused "TypeError: 'NoneType' object is not callable.

added return value.